### PR TITLE
rename syscallfs.FS.Utimes to syscallfs.FS.Chtimes

### DIFF
--- a/internal/syscallfs/adapter.go
+++ b/internal/syscallfs/adapter.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	pathutil "path"
 	"syscall"
+	"time"
 )
 
 // Adapt returns a read-only FS unless the input is already one.
@@ -78,7 +79,7 @@ func (ro *adapter) Unlink(path string) error {
 	return syscall.ENOSYS
 }
 
-// Utimes implements FS.Utimes
-func (ro *adapter) Utimes(path string, atimeNsec, mtimeNsec int64) error {
+// Chtimes implements FS.Chtimes
+func (ro *adapter) Chtimes(path string, atim, mtim time.Time) error {
 	return syscall.ENOSYS
 }

--- a/internal/syscallfs/adapter_test.go
+++ b/internal/syscallfs/adapter_test.go
@@ -7,6 +7,7 @@ import (
 	pathutil "path"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
@@ -66,7 +67,7 @@ func TestAdapt_Unlink(t *testing.T) {
 	require.Equal(t, syscall.ENOSYS, err)
 }
 
-func TestAdapt_Utimes(t *testing.T) {
+func TestAdapt_Chtimes(t *testing.T) {
 	dir := t.TempDir()
 
 	testFS := Adapt(os.DirFS(dir))
@@ -75,7 +76,8 @@ func TestAdapt_Utimes(t *testing.T) {
 	realPath := pathutil.Join(dir, path)
 	require.NoError(t, os.WriteFile(realPath, []byte{}, 0o600))
 
-	err := testFS.Utimes(path, 1, 1)
+	now := time.Now()
+	err := testFS.Chtimes(path, now, now)
 	require.Equal(t, syscall.ENOSYS, err)
 }
 

--- a/internal/syscallfs/dirfs.go
+++ b/internal/syscallfs/dirfs.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"syscall"
+	"time"
 )
 
 func NewDirFS(dir string) (FS, error) {
@@ -70,10 +71,7 @@ func (dir dirFS) Unlink(name string) error {
 	return adjustUnlinkError(err)
 }
 
-// Utimes implements FS.Utimes
-func (dir dirFS) Utimes(name string, atimeNsec, mtimeNsec int64) error {
-	return syscall.UtimesNano(path.Join(string(dir), name), []syscall.Timespec{
-		syscall.NsecToTimespec(atimeNsec),
-		syscall.NsecToTimespec(mtimeNsec),
-	})
+// Chtimes implements FS.Chtimes
+func (dir dirFS) Chtimes(name string, atim, mtim time.Time) error {
+	return os.Chtimes(path.Join(string(dir), name), atim, mtim)
 }

--- a/internal/syscallfs/empty.go
+++ b/internal/syscallfs/empty.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"syscall"
+	"time"
 )
 
 // EmptyFS is an FS that returns syscall.ENOENT for all read functions, and
@@ -47,7 +48,7 @@ func (empty) Unlink(path string) error {
 	return syscall.ENOSYS
 }
 
-// Utimes implements FS.Utimes
-func (empty) Utimes(path string, atimeNsec, mtimeNsec int64) error {
+// Chtimes implements FS.Chtimes
+func (empty) Chtimes(path string, atim, mtim time.Time) error {
 	return syscall.ENOSYS
 }

--- a/internal/syscallfs/readfs.go
+++ b/internal/syscallfs/readfs.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"syscall"
+	"time"
 )
 
 func NewReadFS(fs FS) FS {
@@ -54,7 +55,7 @@ func (r *readFS) Unlink(path string) error {
 	return syscall.ENOSYS
 }
 
-// Utimes implements FS.Utimes
-func (r *readFS) Utimes(path string, atimeNsec, mtimeNsec int64) error {
+// Chtimes implements FS.Chtimes
+func (r *readFS) Chtimes(path string, atim, mtim time.Time) error {
 	return syscall.ENOSYS
 }

--- a/internal/syscallfs/readfs_test.go
+++ b/internal/syscallfs/readfs_test.go
@@ -6,6 +6,7 @@ import (
 	pathutil "path"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/tetratelabs/wazero/internal/testing/require"
 )
@@ -65,7 +66,7 @@ func TestReadFS_Unlink(t *testing.T) {
 	require.Equal(t, syscall.ENOSYS, err)
 }
 
-func TestReadFS_Utimes(t *testing.T) {
+func TestReadFS_Chtimes(t *testing.T) {
 	dir := t.TempDir()
 
 	testFS := NewReadFS(dirFS(dir))
@@ -74,7 +75,8 @@ func TestReadFS_Utimes(t *testing.T) {
 	realPath := pathutil.Join(dir, path)
 	require.NoError(t, os.WriteFile(realPath, []byte{}, 0o600))
 
-	err := testFS.Utimes(path, 1, 1)
+	now := time.Now()
+	err := testFS.Chtimes(path, now, now)
 	require.Equal(t, syscall.ENOSYS, err)
 }
 

--- a/internal/syscallfs/syscallfs.go
+++ b/internal/syscallfs/syscallfs.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"time"
 )
 
 // FS is a writeable fs.FS bridge backed by syscall functions needed for ABI
@@ -90,7 +91,7 @@ type FS interface {
 	//   - syscall.EISDIR: `path` exists, but is a directory.
 	Unlink(path string) error
 
-	// Utimes is similar to syscall.UtimesNano, except the path is relative to
+	// Chtimes is similar to os.Chitmes, except the path is relative to
 	// this file system.
 	//
 	// # Errors
@@ -102,9 +103,9 @@ type FS interface {
 	// # Notes
 	//
 	//   - To set wall clock time, retrieve it first from sys.Walltime.
-	//   - syscall.UtimesNano cannot change the ctime. Also, neither WASI nor
+	//   - os.Chtimes cannot change the ctime. Also, neither WASI nor
 	//     runtime.GOOS=js support changing it. Hence, ctime it is absent here.
-	Utimes(path string, atimeNsec, mtimeNsec int64) error
+	Chtimes(path string, atim, ctim time.Time) error
 }
 
 // maskForReads masks the file with read-only interfaces used by wazero.


### PR DESCRIPTION
This PR demonstrates changing the `Utimes` method accepting timestamps as integers to a `Chtimes` method accepting timestamps as `time.Time` values.

Signed-off-by: Achille Roussel <achille.roussel@gmail.com>