### PR TITLE
add syscallfs.File interface

### DIFF
--- a/internal/syscallfs/adapter.go
+++ b/internal/syscallfs/adapter.go
@@ -2,6 +2,7 @@ package syscallfs
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	pathutil "path"
@@ -31,7 +32,7 @@ func (ro *adapter) Path() string {
 }
 
 // OpenFile implements FS.OpenFile
-func (ro *adapter) OpenFile(path string, flag int, perm fs.FileMode) (fs.File, error) {
+func (ro *adapter) OpenFile(path string, flag int, perm fs.FileMode) (File, error) {
 	if flag != 0 && flag != os.O_RDONLY {
 		return nil, syscall.ENOSYS
 	}
@@ -42,7 +43,7 @@ func (ro *adapter) OpenFile(path string, flag int, perm fs.FileMode) (fs.File, e
 		// wrapped is fine while FS.OpenFile emulates os.OpenFile vs syscall.OpenFile.
 		return nil, err
 	}
-	return maskForReads(f), nil
+	return &adapterFile{f}, nil
 }
 
 func cleanPath(name string) string {
@@ -81,4 +82,36 @@ func (ro *adapter) Unlink(path string) error {
 // Utimes implements FS.Utimes
 func (ro *adapter) Utimes(path string, atimeNsec, mtimeNsec int64) error {
 	return syscall.ENOSYS
+}
+
+type adapterFile struct{ fs.File }
+
+func (f *adapterFile) ReadAt(b []byte, off int64) (int, error) {
+	if r, ok := f.File.(io.ReaderAt); ok {
+		return r.ReadAt(b, off)
+	}
+	return 0, syscall.ENOSYS
+}
+
+func (f *adapterFile) ReadDir(n int) ([]fs.DirEntry, error) {
+	if d, ok := f.File.(fs.ReadDirFile); ok {
+		return d.ReadDir(n)
+	}
+	// TOOD: return ENOTDIR if called on a file which is not a directory
+	return nil, syscall.ENOSYS
+}
+
+func (f *adapterFile) Seek(offset int64, whence int) (int64, error) {
+	if s, ok := f.File.(io.Seeker); ok {
+		return s.Seek(offset, whence)
+	}
+	return 0, syscall.ENOSYS
+}
+
+func (f *adapterFile) Write([]byte) (int, error) {
+	return 0, syscall.ENOSYS
+}
+
+func (f *adapterFile) WriteAt([]byte, int64) (int, error) {
+	return 0, syscall.ENOSYS
 }

--- a/internal/syscallfs/dirfs.go
+++ b/internal/syscallfs/dirfs.go
@@ -32,16 +32,8 @@ func (dir dirFS) Path() string {
 }
 
 // OpenFile implements FS.OpenFile
-func (dir dirFS) OpenFile(name string, flag int, perm fs.FileMode) (fs.File, error) {
-	f, err := os.OpenFile(path.Join(string(dir), name), flag, perm)
-	if err != nil {
-		return nil, err
-	}
-
-	if flag == 0 || flag == os.O_RDONLY {
-		return maskForReads(f), nil
-	}
-	return f, nil
+func (dir dirFS) OpenFile(name string, flag int, perm fs.FileMode) (File, error) {
+	return os.OpenFile(path.Join(string(dir), name), flag, perm)
 }
 
 // Mkdir implements FS.Mkdir

--- a/internal/syscallfs/empty.go
+++ b/internal/syscallfs/empty.go
@@ -23,7 +23,7 @@ func (empty) Path() string {
 }
 
 // OpenFile implements FS.OpenFile
-func (empty) OpenFile(path string, flag int, perm fs.FileMode) (fs.File, error) {
+func (empty) OpenFile(path string, flag int, perm fs.FileMode) (File, error) {
 	return nil, &fs.PathError{Op: "open", Path: path, Err: syscall.ENOENT}
 }
 

--- a/internal/syscallfs/readfs.go
+++ b/internal/syscallfs/readfs.go
@@ -27,7 +27,7 @@ func (r *readFS) Path() string {
 }
 
 // OpenFile implements FS.OpenFile
-func (r *readFS) OpenFile(path string, flag int, perm fs.FileMode) (fs.File, error) {
+func (r *readFS) OpenFile(path string, flag int, perm fs.FileMode) (File, error) {
 	if flag == 0 || flag == os.O_RDONLY {
 		return r.fs.OpenFile(path, flag, perm)
 	}

--- a/internal/syscallfs/syscallfs_test.go
+++ b/internal/syscallfs/syscallfs_test.go
@@ -67,10 +67,6 @@ func testFS_Open_Read(t *testing.T, tmpDir string, testFS FS) {
 		require.Equal(t, 1, len(e))
 		require.False(t, e[0].IsDir())
 		require.Equal(t, file1, e[0].Name())
-
-		// Ensure it doesn't implement io.Writer
-		_, ok = f.(io.Writer)
-		require.False(t, ok)
 	})
 
 	t.Run("file exists", func(t *testing.T) {
@@ -97,9 +93,5 @@ func testFS_Open_Read(t *testing.T, tmpDir string, testFS FS) {
 		b, err := io.ReadAll(f)
 		require.NoError(t, err)
 		require.Equal(t, fileContents[1:], b)
-
-		// Ensure it doesn't implement io.Writer
-		_, ok = f.(io.Writer)
-		require.False(t, ok)
 	})
 }

--- a/internal/syscallfs/syscallfstest/fs_read_write.go
+++ b/internal/syscallfs/syscallfstest/fs_read_write.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path"
@@ -480,7 +479,7 @@ func writeFile(fsys syscallfs.FS, path string, data []byte) error {
 	}
 	defer f.Close()
 	if len(data) > 0 {
-		_, err := f.(io.Writer).Write(data)
+		_, err := f.Write(data)
 		if err != nil {
 			return err
 		}

--- a/internal/syscallfs/syscallfstest/fs_read_write.go
+++ b/internal/syscallfs/syscallfstest/fs_read_write.go
@@ -102,15 +102,11 @@ var OpenFileTests = TestFS{
 					return err
 				}
 			}
-			f, err := fsys.OpenFile(directory, os.O_RDONLY, 0)
+			d, err := fsys.OpenFile(directory, os.O_RDONLY, 0)
 			if err != nil {
 				return err
 			}
-			defer f.Close()
-			d, ok := f.(fs.ReadDirFile)
-			if !ok {
-				return fmt.Errorf("the open file is not a directory")
-			}
+			defer d.Close()
 			entries, err := d.ReadDir(-1)
 			if err != nil {
 				return err


### PR DESCRIPTION
This PR demonstrate the definition of a `syscallfs.File` interface.

Signed-off-by: Achille Roussel <achille.roussel@gmail.com>